### PR TITLE
feat: introduce Note module; flow Note values end-to-end (#27)

### DIFF
--- a/docs/adr/0004-signed-offset-accidental.md
+++ b/docs/adr/0004-signed-offset-accidental.md
@@ -1,0 +1,9 @@
+# Note accidental is a signed semitone offset, not a sharp/flat string
+
+A Note carries its accidental as `offset: -1 | 0 | 1` (♭ = -1, ♮ = 0, ♯ = +1) rather than a `'sharp' | 'flat' | 'natural'` string. Note practice only ever uses these three values, so a string union would model the domain just as faithfully today.
+
+**Decision:** represent the accidental as a signed numeric offset. The `natural` / `sharp` / `flat` constructors map to `0` / `+1` / `-1`; `format` turns the offset back into a glyph via a single lookup.
+
+**Why:** a planned later feature — interval practice (#30/#31) — needs double accidentals (𝄫/𝄪) and arithmetic (`pitchClass`, `transpose`, `simplify`). With the offset already in place, that is a one-line widening of the range from `-1..+1` to `-2..+2`, not a representation migration touching every note constructor and consumer. This is a deliberate, zero-cost prefactor.
+
+**Note for future readers:** do **not** add ±2 support or interval logic to satisfy this ADR alone — the range stays `-1..+1` until interval practice actually lands. This records only *why* the representation is numeric.

--- a/src/components/Notes.tsx
+++ b/src/components/Notes.tsx
@@ -1,19 +1,20 @@
 import { FC } from 'react';
 
-import { NOTE_COLORS, NoteLetter } from '../consts';
+import { NOTE_COLORS } from '../consts';
+import { format, type Note } from '../note';
 
-export const Notes: FC<{ notes: string[] }> = ({ notes = [] }) => {
+export const Notes: FC<{ notes: Note[] }> = ({ notes = [] }) => {
   return (
     <div className="flex flex-wrap items-center content-center justify-center gap-4">
       {notes.map((note, index) => {
-        const colorClass = NOTE_COLORS[note[0] as NoteLetter];
-        return <Note key={note + index} colorClass={colorClass} text={note} />;
+        const colorClass = NOTE_COLORS[note.letter];
+        return <NoteView key={format(note) + index} colorClass={colorClass} text={format(note)} />;
       })}
     </div>
   );
 };
 
-export const Note: FC<{
+export const NoteView: FC<{
   colorClass: string;
   text: string;
 }> = ({ text, colorClass }) => {

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -1,7 +1,7 @@
 import { omitBy } from './utils/omitBy';
+import { flat, natural, sharp, type Note } from './note';
 
 export type NoteLetter = 'A' | 'B' | 'C' | 'D' | 'E' | 'F' | 'G';
-export type NoteMod = '♯' | '♭';
 export type ChordMod = 'M' | 'm'; // TODO: sus, diminished etc - could use –+Δo7 etc
 
 export const DEFAULT_NOTES_COUNT = 12;
@@ -22,21 +22,52 @@ export const NOTE_COLORS: Record<NoteLetter, string> = {
 };
 
 export const NATURAL_NOTES: NoteLetter[] = ['A', 'B', 'C', 'D', 'E', 'F', 'G'];
-export const SHARP_NOTES = omitBy(NATURAL_NOTES, ['B', 'E']).map((note) => note + '♯');
-export const FLAT_NOTES = omitBy(NATURAL_NOTES, ['C', 'F']).map((note) => note + '♭');
+export const SHARP_NOTES: Note[] = omitBy<NoteLetter>(NATURAL_NOTES, ['B', 'E']).map(sharp);
+export const FLAT_NOTES: Note[] = omitBy<NoteLetter>(NATURAL_NOTES, ['C', 'F']).map(flat);
 
-export const INVERSION_GROUPS = [
-  ['C', 'F', 'G'],
-  ['A', 'D', 'E'],
-  ['Ab', 'Db', 'Eb'],
-  ['B', 'Bb', 'Gb'],
+export const INVERSION_GROUPS: Note[][] = [
+  [natural('C'), natural('F'), natural('G')],
+  [natural('A'), natural('D'), natural('E')],
+  [flat('A'), flat('D'), flat('E')],
+  [natural('B'), flat('B'), flat('G')],
 ];
 
-export const CIRCLE_OF_FIFTHS = ['C', 'F', 'Bb', 'Eb', 'Ab', 'Db', 'Gb', 'B', 'E', 'A', 'D', 'G'];
+export const CIRCLE_OF_FIFTHS: Note[] = [
+  natural('C'),
+  natural('F'),
+  flat('B'),
+  flat('E'),
+  flat('A'),
+  flat('D'),
+  flat('G'),
+  natural('B'),
+  natural('E'),
+  natural('A'),
+  natural('D'),
+  natural('G'),
+];
 
 // Parked: raw data for the fifths-flats / fifths-sharps filters. Left out of the
 // note-set registry (unshippable until verified) but retained here — see noteSets.ts.
 /* Are these all Major? */
 /* Are these actually in the right order ?*/
-export const CIRCLE_OF_FIFTHS_FLATS = ['C', 'F', 'Bb', 'Eb', 'Ab', 'Db', 'Gb', 'Cb'];
-export const CIRCLE_OF_FIFTHS_SHARPS = ['C', 'G', 'D', 'A', 'E', 'B', 'F#', 'C#'];
+export const CIRCLE_OF_FIFTHS_FLATS: Note[] = [
+  natural('C'),
+  natural('F'),
+  flat('B'),
+  flat('E'),
+  flat('A'),
+  flat('D'),
+  flat('G'),
+  flat('C'),
+];
+export const CIRCLE_OF_FIFTHS_SHARPS: Note[] = [
+  natural('C'),
+  natural('G'),
+  natural('D'),
+  natural('A'),
+  natural('E'),
+  natural('B'),
+  sharp('F'),
+  sharp('C'),
+];

--- a/src/note.ts
+++ b/src/note.ts
@@ -1,0 +1,27 @@
+import type { NoteLetter } from './consts';
+
+// A structured note value. `offset` is a signed semitone offset from the
+// natural letter (♭ = -1, ♮ = 0, ♯ = +1). Note practice only ever uses
+// -1 | 0 | 1; the signed representation lets interval practice later widen
+// the range to double accidentals (see #31) as a one-line change rather than
+// a representation migration.
+export type Offset = -1 | 0 | 1;
+
+export type Note = {
+  letter: NoteLetter;
+  offset: Offset;
+  quality?: 'minor';
+};
+
+// The app originates every note, so there is no `parse`: a note-string parser
+// would be a hypothetical seam with no caller.
+export const natural = (letter: NoteLetter): Note => ({ letter, offset: 0 });
+export const sharp = (letter: NoteLetter): Note => ({ letter, offset: 1 });
+export const flat = (letter: NoteLetter): Note => ({ letter, offset: -1 });
+export const minor = (note: Note): Note => ({ ...note, quality: 'minor' });
+
+const ACCIDENTAL: Record<Offset, string> = { [-1]: '♭', [0]: '', [1]: '♯' };
+
+// Rendered form, e.g. 'A', 'A♯', 'A♭', 'Am', 'A♯m'. Called only at the render leaf.
+export const format = (note: Note): string =>
+  `${note.letter}${ACCIDENTAL[note.offset]}${note.quality === 'minor' ? 'm' : ''}`;

--- a/src/noteSets.test.ts
+++ b/src/noteSets.test.ts
@@ -1,25 +1,33 @@
 import { describe, it, expect } from 'vitest';
 import { getNotes, noteSets, NOTE_FILTERS } from './noteSets';
 import { createRandom, type Random } from './random';
+import { format, natural, type Note } from './note';
 import { NATURAL_NOTES, FLAT_NOTES, SHARP_NOTES, CIRCLE_OF_FIFTHS } from './consts';
 
-const letter = (note: string) => note[0];
+const asFormatted = (notes: Note[]) => notes.map(format).sort();
 const asSet = (arr: string[]) => [...arr].sort();
 
 describe('getNotes per filter (seeded Random)', () => {
   it('naturals returns the seven natural letters', () => {
     const notes = getNotes({ filter: 'naturals', count: 7 }, createRandom(1));
-    expect(asSet(notes)).toEqual(asSet(NATURAL_NOTES));
+    expect(asSet(notes.map((n) => n.letter))).toEqual(asSet(NATURAL_NOTES));
+    expect(notes.every((n) => n.offset === 0 && n.quality === undefined)).toBe(true);
   });
 
   it('flats draws from naturals plus flats', () => {
     const notes = getNotes({ filter: 'flats', count: 12 }, createRandom(1));
-    expect(asSet(notes)).toEqual(asSet([...NATURAL_NOTES, ...FLAT_NOTES]));
+    expect(asFormatted(notes)).toEqual(
+      asFormatted([...NATURAL_NOTES.map(natural), ...FLAT_NOTES])
+    );
+    expect(notes.some((n) => format(n).endsWith('♭'))).toBe(true);
   });
 
   it('sharps draws from naturals plus sharps', () => {
     const notes = getNotes({ filter: 'sharps', count: 12 }, createRandom(1));
-    expect(asSet(notes)).toEqual(asSet([...NATURAL_NOTES, ...SHARP_NOTES]));
+    expect(asFormatted(notes)).toEqual(
+      asFormatted([...NATURAL_NOTES.map(natural), ...SHARP_NOTES])
+    );
+    expect(notes.some((n) => format(n).endsWith('♯'))).toBe(true);
   });
 
   it('fifths returns the circle of fifths in order', () => {
@@ -30,7 +38,7 @@ describe('getNotes per filter (seeded Random)', () => {
   it('any yields a full octave of naturals plus one accidental family', () => {
     const notes = getNotes({ filter: 'any', count: 12 }, createRandom(1));
     expect(notes).toHaveLength(12);
-    const letters = notes.map(letter);
+    const letters = notes.map((n) => n.letter);
     expect(asSet([...new Set(letters)])).toEqual(asSet(NATURAL_NOTES));
   });
 
@@ -59,7 +67,7 @@ describe('40% minor probability (any-add-minor)', () => {
     for (let round = 0; round < 3000; round++) {
       const notes = getNotes({ filter: 'any-add-minor', count: 12 }, rng);
       total += notes.length;
-      minors += notes.filter((n) => n.endsWith('m')).length;
+      minors += notes.filter((n) => n.quality === 'minor').length;
     }
     expect(minors / total).toBeCloseTo(0.4, 1);
   });
@@ -69,8 +77,15 @@ describe('40% minor probability (any-add-minor)', () => {
     // Stub: never flat (use sharps), always minor; identity shuffle.
     const stub: Random = { chance: (p) => p !== 0.5, shuffle: (arr) => arr };
     const notes = getNotes({ filter: 'any-add-minor', count: 12 }, stub);
-    expect(notes.every((n) => n.endsWith('m'))).toBe(true);
-    expect(notes.map((n) => n.replace(/m$/, ''))).toEqual([...NATURAL_NOTES, ...SHARP_NOTES]);
+    expect(notes.every((n) => n.quality === 'minor')).toBe(true);
+    expect(notes.every((n) => format(n).endsWith('m'))).toBe(true);
+    const bases = notes.map((n) => ({ letter: n.letter, offset: n.offset }));
+    expect(bases).toEqual(
+      [...NATURAL_NOTES.map(natural), ...SHARP_NOTES].map((n) => ({
+        letter: n.letter,
+        offset: n.offset,
+      }))
+    );
   });
 });
 

--- a/src/noteSets.ts
+++ b/src/noteSets.ts
@@ -5,6 +5,7 @@ import {
   NATURAL_NOTES,
   SHARP_NOTES,
 } from './consts';
+import { minor, natural, type Note } from './note';
 import { defaultRandom, type Random } from './random';
 
 // Probability a note is presented as minor (see PRD — preserved exactly).
@@ -15,18 +16,19 @@ const MINOR_PROBABILITY = 0.4;
 const getOctaveSet = (
   rng: Random,
   { flats = false, sharps = false, minors = false } = {}
-): string[] => {
-  let notes: string[] = [...NATURAL_NOTES];
+): Note[] => {
+  const naturals = NATURAL_NOTES.map(natural);
+  let notes: Note[] = naturals;
 
-  if (flats) notes = [...NATURAL_NOTES, ...FLAT_NOTES];
-  if (sharps) notes = [...NATURAL_NOTES, ...SHARP_NOTES];
-  if (minors) notes = notes.map((n) => (rng.chance(MINOR_PROBABILITY) ? n + 'm' : n));
+  if (flats) notes = [...naturals, ...FLAT_NOTES];
+  if (sharps) notes = [...naturals, ...SHARP_NOTES];
+  if (minors) notes = notes.map((n) => (rng.chance(MINOR_PROBABILITY) ? minor(n) : n));
 
   return notes;
 };
 
 // A full octave that randomly leans flat or sharp (a fair coin flip).
-const getRandomSet = (rng: Random, { minors = false } = {}): string[] => {
+const getRandomSet = (rng: Random, { minors = false } = {}): Note[] => {
   const useFlats = rng.chance(0.5);
   return getOctaveSet(rng, { flats: useFlats, sharps: !useFlats, minors });
 };
@@ -82,7 +84,7 @@ export type NoteSetConfig = {
 export const getNotes = (
   { filter = DEFAULT_NOTES_FILTER, count = 6 }: NoteSetConfig = {},
   rng: Random = defaultRandom
-): string[] => {
+): Note[] => {
   const noteSet = noteSets.find((set) => set.id === filter) ?? noteSets[0];
   return noteSet.generate(rng).slice(0, count);
 };

--- a/src/utils/omitBy.ts
+++ b/src/utils/omitBy.ts
@@ -1,2 +1,2 @@
-export const omitBy = (arr: string[], ignores: string[]) =>
+export const omitBy = <T>(arr: T[], ignores: T[]): T[] =>
   arr.filter((a) => ignores.every((b) => a !== b));


### PR DESCRIPTION
## What

Implements #27. Replaces the stringly-typed note with a structured `Note` value that flows from generation to the render leaf.

- **`src/note.ts`** — new domain module: `Note = { letter, offset, quality? }`, signed accidental `offset: -1 | 0 | 1` (♭/♮/♯), constructors `natural`/`sharp`/`flat`/`minor`, and `format`. No `parse` — the app originates every note.
- **`consts.ts`** — `INVERSION_GROUPS`, `CIRCLE_OF_FIFTHS`, and the parked fifths arrays re-authored as `Note[]` via the constructors. Resolves the mixed `♯/♭` vs `#/b` encoding.
- **`noteSets.ts`** — `getNotes` returns `Note[]`; `minor()` replaces the `+ 'm'` string suffix.
- **`Notes.tsx`** — `format` called only at the render leaf; colour lookup reads `note.letter` (the `as NoteLetter` cast is gone).
- **`omitBy`** — made generic so it preserves `NoteLetter`.
- **ADR-0004** — records why the accidental is a signed numeric offset (zero-cost prefactor for interval practice #31, avoids ±2 support now).

## Design note

Accidental is a signed `offset` even though note practice only uses `-1 | 0 | 1`. Deliberate prefactor: interval practice (#31) widens the range to double accidentals as a one-line change instead of a representation migration. No ±2 or interval logic added here.

## Verification

- `vitest run` — 21 passing (noteSets tests updated to the `Note[]` contract; formatting covered through `getNotes`, no dedicated `format` seam)
- `tsc --noEmit` — clean
- `eslint .` — clean
- `vite build` — clean

Closes #27