### PR TITLE
feat: extract usePracticeSession hook (#28)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,37 +1,14 @@
-import { useCallback, useState } from 'react';
-
-import { DEFAULT_NOTES_COUNT } from './consts';
-import { DEFAULT_NOTES_FILTER, getNotes, NoteSetFilter } from './noteSets';
 import { Notes } from './components/Notes';
 import { Settings } from './components/Settings';
-import { useInterval } from './useInterval';
+import { usePracticeSession } from './usePracticeSession';
 
 const App = () => {
-  const [count, setCount] = useState(DEFAULT_NOTES_COUNT);
-  const [filter, setFilter] = useState<NoteSetFilter>(DEFAULT_NOTES_FILTER);
-  const [notes, setNotes] = useState(getNotes({ filter, count }));
-
-  // null pauses timer
-  const [timerDelay, setTimerDelay] = useState<number | null>(null);
-
-  const changeNotes = useCallback(
-    (overrides = {}) => setNotes(getNotes({ filter, count, ...overrides })),
-    [filter, count, setNotes]
-  );
-
-  const handleTap = useCallback(() => {
-    if (timerDelay !== null) {
-      // force interval to reset by adding 1ms in case value was the same
-      setTimerDelay(timerDelay + 1);
-    }
-    changeNotes();
-  }, [changeNotes, timerDelay, setTimerDelay]);
-
-  useInterval(changeNotes, timerDelay);
+  const { notes, filter, setFilter, count, setCount, maxCount, setTimerSeconds, refresh } =
+    usePracticeSession();
 
   return (
     <div className="flex flex-col h-dvh bg-gray-900">
-      <div className="flex-1 w-full max-w-6xl p-4 mx-auto select-none" onClick={handleTap}>
+      <div className="flex-1 w-full max-w-6xl p-4 mx-auto select-none" onClick={refresh}>
         <Notes notes={notes} />
       </div>
       <div className="my-4 text-sm italic text-center text-gray-100 opacity-25">
@@ -39,12 +16,12 @@ const App = () => {
       </div>
       <div className="grid grid-rows-3 px-4 pt-4 bg-gray-300 md:grid-cols-3 md:grid-rows-1">
         <Settings
-          count={count}
           filter={filter}
           setFilter={setFilter}
-          setTimerDelay={setTimerDelay}
+          count={count}
+          maxCount={maxCount}
           setCount={setCount}
-          changeNotes={changeNotes}
+          setTimerSeconds={setTimerSeconds}
         />
       </div>
     </div>

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -1,6 +1,5 @@
-import { useCallback, Dispatch, SetStateAction, FC, memo, ChangeEvent, FocusEvent } from 'react';
+import { ChangeEvent, FC, FocusEvent, memo, useCallback } from 'react';
 
-import { NATURAL_NOTES_COUNT, MAX_NOTES_COUNT } from '../../consts';
 import { NoteSetFilter } from '../../noteSets';
 
 import { Filter } from './Filter';
@@ -9,46 +8,30 @@ import { Count } from './Count';
 
 type InputEvent = ChangeEvent<HTMLInputElement> | FocusEvent<HTMLInputElement>;
 
-// seconds -> ms | null
-const parseDelay = (timerDelay: string): number | null => {
-  const val = parseInt(timerDelay);
-  const shouldReset = !Number.isFinite(val) || val <= 0;
-  return shouldReset ? null : val * 1000;
-};
-
+// The DOM adapter: it turns raw input events into domain calls on the session's
+// setters. All parse/clamp lives in the leaf controls (Count/Timer) and the
+// session enforces its own invariants — Settings only translates.
 export const Settings: FC<{
   filter: NoteSetFilter;
   count: number;
-  setTimerDelay: Dispatch<SetStateAction<number | null>>;
-  setCount: Dispatch<SetStateAction<number>>;
-  setFilter: Dispatch<SetStateAction<NoteSetFilter>>;
-  changeNotes: (overrides?: { filter?: NoteSetFilter; count?: number }) => void;
-}> = memo(({ filter, count, setTimerDelay, setCount, setFilter, changeNotes }) => {
-  const maxNoteCount = filter === 'naturals' ? NATURAL_NOTES_COUNT : MAX_NOTES_COUNT;
-
-  const handleDelayChange = useCallback(
-    ({ target }: InputEvent) => {
-      setTimerDelay(parseDelay(target.value));
-    },
-    [setTimerDelay]
+  maxCount: number;
+  setFilter: (filter: NoteSetFilter) => void;
+  setCount: (count: number) => void;
+  setTimerSeconds: (seconds: number | null) => void;
+}> = memo(({ filter, count, maxCount, setFilter, setCount, setTimerSeconds }) => {
+  const handleFilterChange = useCallback(
+    ({ target }: ChangeEvent<HTMLSelectElement>) => setFilter(target.value as NoteSetFilter),
+    [setFilter]
   );
 
   const handleCountChange = useCallback(
-    ({ target }: InputEvent) => {
-      const count = parseInt(target.value);
-      setCount(count);
-      changeNotes({ count });
-    },
-    [setCount, changeNotes]
+    ({ target }: InputEvent) => setCount(parseInt(target.value)),
+    [setCount]
   );
 
-  const handleFilterChange = useCallback(
-    ({ target }: ChangeEvent<HTMLSelectElement>) => {
-      const filter = target.value as NoteSetFilter;
-      setFilter(filter);
-      changeNotes({ filter });
-    },
-    [setFilter, changeNotes]
+  const handleTimerChange = useCallback(
+    ({ target }: InputEvent) => setTimerSeconds(parseInt(target.value)),
+    [setTimerSeconds]
   );
 
   return (
@@ -57,10 +40,10 @@ export const Settings: FC<{
         <Filter value={filter} onChange={handleFilterChange} />
       </div>
       <div className="flex justify-center mb-4 ">
-        <Timer onChange={handleDelayChange} />
+        <Timer onChange={handleTimerChange} />
       </div>
       <div className="flex justify-center mb-4 md:justify-end">
-        <Count value={count} max={maxNoteCount} onChange={handleCountChange} />
+        <Count value={count} max={maxCount} onChange={handleCountChange} />
       </div>
     </>
   );

--- a/src/useInterval.ts
+++ b/src/useInterval.ts
@@ -1,7 +1,9 @@
 import { useEffect, useRef } from 'react';
 
 // Self-hosted interval (replaces react-use's useInterval). A null delay pauses.
-export const useInterval = (callback: () => void, delay: number | null) => {
+// Changing `resetKey` restarts the interval without changing the delay, so a
+// caller can reset the countdown (e.g. on a manual tap) as a hidden detail.
+export const useInterval = (callback: () => void, delay: number | null, resetKey?: unknown) => {
   const savedCallback = useRef(callback);
 
   useEffect(() => {
@@ -12,5 +14,5 @@ export const useInterval = (callback: () => void, delay: number | null) => {
     if (delay === null) return;
     const id = setInterval(() => savedCallback.current(), delay);
     return () => clearInterval(id);
-  }, [delay]);
+  }, [delay, resetKey]);
 };

--- a/src/usePracticeSession.test.ts
+++ b/src/usePracticeSession.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+import { usePracticeSession } from './usePracticeSession';
+import { createRandom } from './random';
+import { DEFAULT_NOTES_COUNT, MAX_NOTES_COUNT, NATURAL_NOTES_COUNT } from './consts';
+import { DEFAULT_NOTES_FILTER } from './noteSets';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// Build the Random once so it is a stable instance whose stream advances across
+// renders — mirroring the production singleton. Creating it inside the render
+// callback would reset the seed every render and defeat the determinism.
+const renderSession = (seed: number) => {
+  const rng = createRandom(seed);
+  return renderHook(() => usePracticeSession(rng));
+};
+
+describe('usePracticeSession — initial state', () => {
+  it('starts on the default filter and count with a full Note Set', () => {
+    const { result } = renderSession(1);
+
+    expect(result.current.filter).toBe(DEFAULT_NOTES_FILTER);
+    expect(result.current.count).toBe(DEFAULT_NOTES_COUNT);
+    expect(result.current.maxCount).toBe(MAX_NOTES_COUNT);
+    expect(result.current.notes).toHaveLength(DEFAULT_NOTES_COUNT);
+  });
+});
+
+describe('usePracticeSession — regenerate on change', () => {
+  it('setFilter switches the filter and regenerates the Note Set', () => {
+    const { result } = renderSession(1);
+
+    act(() => result.current.setFilter('naturals'));
+
+    expect(result.current.filter).toBe('naturals');
+    // naturals are the seven plain letters — offset 0, no quality.
+    expect(result.current.notes.every((n) => n.offset === 0 && n.quality === undefined)).toBe(true);
+  });
+
+  it('setCount changes the count and reslices the Note Set', () => {
+    const { result } = renderSession(1);
+
+    act(() => result.current.setCount(4));
+
+    expect(result.current.count).toBe(4);
+    expect(result.current.notes).toHaveLength(4);
+  });
+
+  it('refresh draws a fresh Note Set', () => {
+    const { result } = renderSession(7);
+    const before = result.current.notes;
+
+    act(() => result.current.refresh());
+
+    expect(result.current.notes).not.toBe(before);
+    expect(result.current.notes).not.toEqual(before);
+  });
+
+  it('setTimerSeconds does not regenerate the Note Set', () => {
+    const { result } = renderSession(1);
+    const before = result.current.notes;
+
+    act(() => result.current.setTimerSeconds(5));
+
+    expect(result.current.notes).toBe(before);
+  });
+});
+
+describe('usePracticeSession — count <= maxCount invariant', () => {
+  it('clamps count down when a filter change lowers the maximum', () => {
+    const { result } = renderSession(1);
+    expect(result.current.count).toBe(DEFAULT_NOTES_COUNT); // 12
+
+    act(() => result.current.setFilter('naturals')); // max drops to 7
+
+    expect(result.current.maxCount).toBe(NATURAL_NOTES_COUNT);
+    expect(result.current.count).toBe(NATURAL_NOTES_COUNT);
+    expect(result.current.notes).toHaveLength(NATURAL_NOTES_COUNT);
+  });
+
+  it('caps a too-large count at the current maximum', () => {
+    const { result } = renderSession(1);
+
+    act(() => result.current.setCount(999));
+
+    expect(result.current.count).toBe(MAX_NOTES_COUNT);
+  });
+});
+
+describe('usePracticeSession — timer', () => {
+  it('auto-refreshes the Note Set on each interval tick', () => {
+    vi.useFakeTimers();
+    const { result } = renderSession(3);
+    const before = result.current.notes;
+
+    act(() => result.current.setTimerSeconds(2));
+    act(() => vi.advanceTimersByTime(2000));
+
+    expect(result.current.notes).not.toEqual(before);
+  });
+
+  it('pauses when the timer is set to zero', () => {
+    vi.useFakeTimers();
+    const { result } = renderSession(3);
+
+    act(() => result.current.setTimerSeconds(2));
+    act(() => result.current.setTimerSeconds(0));
+    const paused = result.current.notes;
+    act(() => vi.advanceTimersByTime(10000));
+
+    expect(result.current.notes).toBe(paused);
+  });
+
+  it('refresh resets the countdown so the interval starts over', () => {
+    vi.useFakeTimers();
+    const { result } = renderSession(3);
+
+    act(() => result.current.setTimerSeconds(2));
+    act(() => vi.advanceTimersByTime(1500)); // no tick yet
+    act(() => result.current.refresh()); // manual refresh resets the interval
+    const afterRefresh = result.current.notes;
+    act(() => vi.advanceTimersByTime(1500)); // only 1.5s since reset < 2s
+
+    expect(result.current.notes).toBe(afterRefresh);
+  });
+});

--- a/src/usePracticeSession.ts
+++ b/src/usePracticeSession.ts
@@ -1,0 +1,102 @@
+import { useCallback, useState } from 'react';
+
+import { DEFAULT_NOTES_COUNT, MAX_NOTES_COUNT, NATURAL_NOTES_COUNT } from './consts';
+import { DEFAULT_NOTES_FILTER, getNotes, type NoteSetFilter } from './noteSets';
+import { defaultRandom, type Random } from './random';
+import type { Note } from './note';
+import { useInterval } from './useInterval';
+
+// The maximum notes a filter can offer: naturals is a seven-note octave,
+// every other filter is a full twelve.
+const maxCountFor = (filter: NoteSetFilter): number =>
+  filter === 'naturals' ? NATURAL_NOTES_COUNT : MAX_NOTES_COUNT;
+
+const clamp = (value: number, min: number, max: number): number =>
+  Math.min(Math.max(value, min), max);
+
+// seconds -> interval delay in ms, or null to pause. Zero, negative, or
+// non-numeric input all pause the timer.
+const secondsToDelay = (seconds: number | null): number | null => {
+  if (seconds === null || !Number.isFinite(seconds) || seconds <= 0) return null;
+  return seconds * 1000;
+};
+
+export type PracticeSession = {
+  notes: Note[];
+  filter: NoteSetFilter;
+  setFilter: (filter: NoteSetFilter) => void;
+  count: number;
+  setCount: (count: number) => void;
+  maxCount: number;
+  setTimerSeconds: (seconds: number | null) => void;
+  refresh: () => void;
+};
+
+// One DOM-free module owning the whole practice session: the filter, count,
+// current Note Set, and the auto-refresh timer with its reset-on-tap. It speaks
+// domain types only (never DOM events) and holds the regenerate-on-change rule
+// and the `count <= maxCount` invariant internally. Randomness is injected and
+// defaults to production, so the app call site stays argument-free.
+export const usePracticeSession = (rng: Random = defaultRandom): PracticeSession => {
+  const [filter, setFilterState] = useState<NoteSetFilter>(DEFAULT_NOTES_FILTER);
+  const [count, setCountState] = useState(DEFAULT_NOTES_COUNT);
+  const [notes, setNotes] = useState<Note[]>(() =>
+    getNotes({ filter: DEFAULT_NOTES_FILTER, count: DEFAULT_NOTES_COUNT }, rng)
+  );
+  // null pauses the timer; a positive number is the auto-refresh delay in ms.
+  const [timerDelay, setTimerDelay] = useState<number | null>(null);
+  // Bumped on every refresh to restart the interval — the hidden reset-on-tap.
+  const [timerNonce, setTimerNonce] = useState(0);
+
+  const maxCount = maxCountFor(filter);
+
+  // The regenerate-on-change rule in one place: any filter/count change draws a
+  // fresh Note Set for that pair.
+  const regenerate = useCallback(
+    (nextFilter: NoteSetFilter, nextCount: number) => {
+      setNotes(getNotes({ filter: nextFilter, count: nextCount }, rng));
+    },
+    [rng]
+  );
+
+  const refresh = useCallback(() => {
+    regenerate(filter, count);
+    setTimerNonce((nonce) => nonce + 1);
+  }, [filter, count, regenerate]);
+
+  const setFilter = useCallback(
+    (next: NoteSetFilter) => {
+      const nextCount = clamp(count, 1, maxCountFor(next));
+      setFilterState(next);
+      setCountState(nextCount);
+      regenerate(next, nextCount);
+    },
+    [count, regenerate]
+  );
+
+  const setCount = useCallback(
+    (next: number) => {
+      const nextCount = clamp(next, 1, maxCountFor(filter));
+      setCountState(nextCount);
+      regenerate(filter, nextCount);
+    },
+    [filter, regenerate]
+  );
+
+  const setTimerSeconds = useCallback((seconds: number | null) => {
+    setTimerDelay(secondsToDelay(seconds));
+  }, []);
+
+  useInterval(refresh, timerDelay, timerNonce);
+
+  return {
+    notes,
+    filter,
+    setFilter,
+    count,
+    setCount,
+    maxCount,
+    setTimerSeconds,
+    refresh,
+  };
+};


### PR DESCRIPTION
## What

Concentrates the practice-session state and the *regenerate-on-change* rule into one DOM-free hook, `usePracticeSession`, removing the split logic, the `overrides` argument, and the stale-closure + `+1ms` interval workarounds.

Implements #28 (child of PRD #25).

## Interface

`usePracticeSession(rng = defaultRandom)` → `{ notes, filter, setFilter, count, setCount, maxCount, setTimerSeconds, refresh }`

- `setFilter` / `setCount` regenerate the Note Set internally
- `setTimerSeconds` sets the interval (0/invalid → paused), does **not** regenerate
- `refresh` regenerates and resets the timer
- `maxCount` derived inside; the `count ≤ maxCount` invariant is enforced when a filter change lowers the maximum
- DOM-free — speaks domain types, never `event.target`

## Notes

- `useInterval` gains an optional `resetKey`; the hook bumps a nonce through it to reset the countdown on tap — the `+1ms` hack is now an internal detail.
- `App` becomes layout; `Settings` becomes a DOM adapter translating input events to the hook's domain setters.
- Randomness is injected (defaults to the production singleton) so the session is deterministic under a seed.

## Tests

`usePracticeSession.test.ts` (10 tests, driven by plain calls): initial state, regenerate-on-change, the `count ≤ maxCount` invariant, and timer set / pause / reset-on-refresh. Full suite: 31 passing; `tsc`, `eslint`, and `vite build` all clean.

Closes #28