### PR TITLE
feat: extract useClampedNumberInput to dedupe Count/Timer (#29)

### DIFF
--- a/src/components/Settings/Count.tsx
+++ b/src/components/Settings/Count.tsx
@@ -1,50 +1,14 @@
-import { ChangeEvent, FC, FocusEvent, useCallback, useRef } from 'react';
-import { DEFAULT_NOTES_COUNT } from '../../consts';
-import { Label } from './Label';
+import { FC } from 'react';
 
-type InputEvent = ChangeEvent<HTMLInputElement> | FocusEvent<HTMLInputElement>;
+import { useClampedNumberInput } from '../../useClampedNumberInput';
+import { Label } from './Label';
 
 export const Count: FC<{
   value: number;
   max: number;
-  onChange: (event: InputEvent) => void;
-}> = ({ value, max, onChange }) => {
-  const lastValidValue = useRef(String(DEFAULT_NOTES_COUNT));
-
-  const handleChange = useCallback(
-    (ev: ChangeEvent<HTMLInputElement>) => {
-      let newValue = ev.target.value;
-      const num = parseInt(ev.target.value);
-
-      if (num <= 0) {
-        newValue = '1';
-      } else if (num > max) {
-        newValue = `${max}`;
-      }
-
-      // hold onto last valid value for reset in blur
-      if (Number.isFinite(num)) {
-        lastValidValue.current = newValue;
-      }
-
-      // update displayed value regardless
-      ev.target.value = newValue;
-      onChange(ev);
-    },
-    [max, onChange]
-  );
-
-  const handleBlur = useCallback(
-    (ev: FocusEvent<HTMLInputElement>) => {
-      // input empty/invalid, reset to last valid value
-      if (!Number.isFinite(parseInt(ev.target.value))) {
-        ev.target.value = lastValidValue.current;
-      }
-
-      onChange(ev);
-    },
-    [onChange]
-  );
+  onValue: (count: number) => void;
+}> = ({ value, max, onValue }) => {
+  const input = useClampedNumberInput({ value, min: 1, max, onValue, resetTo: 'last-valid' });
 
   return (
     <div className="flex items-center">
@@ -53,9 +17,7 @@ export const Count: FC<{
         id="note-count"
         className="w-12 px-1 py-1 text-gray-900 bg-white border border-gray-400 rounded"
         type="number"
-        value={value}
-        onChange={handleChange}
-        onBlur={handleBlur}
+        {...input}
       />
     </div>
   );

--- a/src/components/Settings/Timer.tsx
+++ b/src/components/Settings/Timer.tsx
@@ -1,52 +1,21 @@
-import { ChangeEvent, FC, FocusEvent, useCallback, useState } from 'react';
+import { FC } from 'react';
 
 import { TIMER_MAX_SECONDS } from '../../consts';
+import { useClampedNumberInput } from '../../useClampedNumberInput';
 import { Label } from './Label';
 
-type InputEvent = ChangeEvent<HTMLInputElement> | FocusEvent<HTMLInputElement>;
-
 export const Timer: FC<{
-  onChange: (event: InputEvent) => void;
-}> = ({ onChange }) => {
-  // track input val internally (but still broadcast change)
-  // otherwise we can get stuck with a `0` on mobile
-  // that cannot be deleted for fresh input due
-  // to null being used as delay value for useInterval
-  const [value, setValue] = useState('0');
-
-  const handleChange = useCallback(
-    (ev: ChangeEvent<HTMLInputElement>) => {
-      const num = parseInt(ev.target.value);
-      let newVal = ev.target.value;
-
-      if (num < 0) {
-        newVal = '0';
-      } else if (num > TIMER_MAX_SECONDS) {
-        newVal = `${TIMER_MAX_SECONDS}`;
-      }
-
-      setValue(newVal);
-      onChange(ev);
-    },
-    [onChange, setValue]
-  );
-
-  const handleBlur = useCallback(
-    (ev: FocusEvent<HTMLInputElement>) => {
-      const val = ev.target.value;
-      const num = parseInt(val);
-
-      // empty input, reset to 0
-      if (!Number.isFinite(num)) {
-        setValue('0');
-      } else {
-        setValue(val);
-      }
-
-      onChange(ev);
-    },
-    [onChange, setValue]
-  );
+  onValue: (seconds: number) => void;
+}> = ({ onValue }) => {
+  // The timer has no external source of truth — it starts paused at 0 and the
+  // input owns its value from there.
+  const input = useClampedNumberInput({
+    value: 0,
+    min: 0,
+    max: TIMER_MAX_SECONDS,
+    onValue,
+    resetTo: 'min',
+  });
 
   return (
     <div className="flex items-center">
@@ -55,9 +24,7 @@ export const Timer: FC<{
         id="note-timer"
         className="w-16 px-1 py-1 text-gray-900 bg-white border border-gray-400 rounded"
         type="number"
-        value={value}
-        onChange={handleChange}
-        onBlur={handleBlur}
+        {...input}
       />
     </div>
   );

--- a/src/components/Settings/index.tsx
+++ b/src/components/Settings/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FC, FocusEvent, memo, useCallback } from 'react';
+import { ChangeEvent, FC, memo, useCallback } from 'react';
 
 import { NoteSetFilter } from '../../noteSets';
 
@@ -6,11 +6,9 @@ import { Filter } from './Filter';
 import { Timer } from './Timer';
 import { Count } from './Count';
 
-type InputEvent = ChangeEvent<HTMLInputElement> | FocusEvent<HTMLInputElement>;
-
-// The DOM adapter: it turns raw input events into domain calls on the session's
-// setters. All parse/clamp lives in the leaf controls (Count/Timer) and the
-// session enforces its own invariants — Settings only translates.
+// The settings row wires the session's domain setters to the three controls.
+// Count and Timer own their own parse/clamp (via useClampedNumberInput); Filter
+// is a plain select. Settings only forwards.
 export const Settings: FC<{
   filter: NoteSetFilter;
   count: number;
@@ -24,26 +22,16 @@ export const Settings: FC<{
     [setFilter]
   );
 
-  const handleCountChange = useCallback(
-    ({ target }: InputEvent) => setCount(parseInt(target.value)),
-    [setCount]
-  );
-
-  const handleTimerChange = useCallback(
-    ({ target }: InputEvent) => setTimerSeconds(parseInt(target.value)),
-    [setTimerSeconds]
-  );
-
   return (
     <>
       <div className="flex justify-center mb-4 md:justify-start">
         <Filter value={filter} onChange={handleFilterChange} />
       </div>
       <div className="flex justify-center mb-4 ">
-        <Timer onChange={handleTimerChange} />
+        <Timer onValue={setTimerSeconds} />
       </div>
       <div className="flex justify-center mb-4 md:justify-end">
-        <Count value={count} max={maxCount} onChange={handleCountChange} />
+        <Count value={count} max={maxCount} onValue={setCount} />
       </div>
     </>
   );

--- a/src/useClampedNumberInput.test.ts
+++ b/src/useClampedNumberInput.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+import { useClampedNumberInput, type ResetTo } from './useClampedNumberInput';
+
+// A minimal stand-in for the input event the handlers read.
+const event = (value: string) => ({ target: { value } }) as React.ChangeEvent<HTMLInputElement>;
+
+const setup = (
+  overrides: Partial<{
+    value: number;
+    min: number;
+    max: number;
+    resetTo: ResetTo;
+  }> = {}
+) => {
+  const onValue = vi.fn();
+  const props = { value: 6, min: 1, max: 12, resetTo: 'last-valid' as ResetTo, onValue, ...overrides };
+  const view = renderHook((p: typeof props) => useClampedNumberInput(p), { initialProps: props });
+  return { onValue, ...view };
+};
+
+describe('useClampedNumberInput — display', () => {
+  it('shows the initial value as a string', () => {
+    const { result } = setup({ value: 6 });
+    expect(result.current.value).toBe('6');
+  });
+
+  it('mirrors an external value change', () => {
+    const { result, rerender } = setup({ value: 12 });
+    expect(result.current.value).toBe('12');
+    // e.g. a filter change clamps the session count down to 7
+    rerender({ value: 7, min: 1, max: 7, resetTo: 'last-valid', onValue: vi.fn() });
+    expect(result.current.value).toBe('7');
+  });
+
+  it('keeps a locally-typed value when the external value is static (timer-style)', () => {
+    const { result, rerender } = setup({ value: 0, min: 0, max: 60, resetTo: 'min' });
+    act(() => result.current.onChange(event('30')));
+    expect(result.current.value).toBe('30');
+    // A re-render that does not change the external value must not clobber the display.
+    rerender({ value: 0, min: 0, max: 60, resetTo: 'min', onValue: vi.fn() });
+    expect(result.current.value).toBe('30');
+  });
+});
+
+describe('useClampedNumberInput — clamp on change', () => {
+  it('clamps a value above the max and emits the clamped number', () => {
+    const { result, onValue } = setup({ min: 1, max: 12 });
+    act(() => result.current.onChange(event('99')));
+    expect(result.current.value).toBe('12');
+    expect(onValue).toHaveBeenLastCalledWith(12);
+  });
+
+  it('clamps a value below the min and emits the clamped number', () => {
+    const { result, onValue } = setup({ min: 1, max: 12 });
+    act(() => result.current.onChange(event('0')));
+    expect(result.current.value).toBe('1');
+    expect(onValue).toHaveBeenLastCalledWith(1);
+  });
+
+  it('passes an in-range value straight through', () => {
+    const { result, onValue } = setup({ min: 1, max: 12 });
+    act(() => result.current.onChange(event('5')));
+    expect(result.current.value).toBe('5');
+    expect(onValue).toHaveBeenLastCalledWith(5);
+  });
+
+  it('allows the field to be emptied without emitting a value (mobile stuck-0 fix)', () => {
+    const { result, onValue } = setup({ min: 0, max: 60 });
+    act(() => result.current.onChange(event('')));
+    expect(result.current.value).toBe('');
+    expect(onValue).not.toHaveBeenCalled();
+  });
+});
+
+describe('useClampedNumberInput — resetTo on blur', () => {
+  it("'last-valid' restores the previous valid value when cleared", () => {
+    const { result, onValue } = setup({ value: 6, min: 1, max: 12, resetTo: 'last-valid' });
+    act(() => result.current.onChange(event('9'))); // 9 becomes the last valid value
+    act(() => result.current.onChange(event(''))); // cleared
+    onValue.mockClear();
+    act(() => result.current.onBlur(event('')));
+    expect(result.current.value).toBe('9');
+    expect(onValue).toHaveBeenLastCalledWith(9);
+  });
+
+  it("'min' resets to the minimum when cleared", () => {
+    const { result, onValue } = setup({ value: 0, min: 0, max: 60, resetTo: 'min' });
+    act(() => result.current.onChange(event('30')));
+    act(() => result.current.onChange(event('')));
+    onValue.mockClear();
+    act(() => result.current.onBlur(event('')));
+    expect(result.current.value).toBe('0');
+    expect(onValue).toHaveBeenLastCalledWith(0);
+  });
+
+  it('leaves a valid value untouched on blur', () => {
+    const { result } = setup({ value: 6, min: 1, max: 12, resetTo: 'last-valid' });
+    act(() => result.current.onChange(event('8')));
+    act(() => result.current.onBlur(event('8')));
+    expect(result.current.value).toBe('8');
+  });
+});

--- a/src/useClampedNumberInput.ts
+++ b/src/useClampedNumberInput.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef, useState, type ChangeEvent, type FocusEvent } from 'react';
+
+// How the control recovers when the field is left empty/invalid on blur:
+// 'last-valid' restores the previous valid value (Count); 'min' resets to the
+// minimum (Timer, so a stuck value can always be cleared back to paused).
+export type ResetTo = 'last-valid' | 'min';
+
+type InputEvent = ChangeEvent<HTMLInputElement> | FocusEvent<HTMLInputElement>;
+
+type Options = {
+  // The controlled value — the domain's source of truth for this input.
+  value: number;
+  min: number;
+  max: number;
+  onValue: (value: number) => void;
+  resetTo: ResetTo;
+};
+
+const clamp = (n: number, min: number, max: number): number => Math.min(Math.max(n, min), max);
+
+// One home for clamped numeric input: parse, clamp to [min, max], the display
+// string that lets the field go transiently empty while editing (the mobile
+// stuck-`0` workaround), and the blur-reset strategy. Emits only valid, clamped
+// numbers through `onValue`; the display mirrors the external `value` so a change
+// elsewhere (e.g. a filter lowering the count) is reflected here.
+export const useClampedNumberInput = ({ value, min, max, onValue, resetTo }: Options) => {
+  const [display, setDisplay] = useState(String(value));
+  const lastValid = useRef(String(value));
+
+  useEffect(() => {
+    setDisplay(String(value));
+    lastValid.current = String(value);
+  }, [value]);
+
+  // Clamp, display, remember, and emit — the shared path for every valid number.
+  const commit = useCallback(
+    (num: number) => {
+      const clamped = clamp(num, min, max);
+      setDisplay(String(clamped));
+      lastValid.current = String(clamped);
+      onValue(clamped);
+    },
+    [min, max, onValue]
+  );
+
+  const onChange = useCallback(
+    ({ target }: InputEvent) => {
+      const num = parseInt(target.value);
+      // Empty or non-numeric: keep the raw text so the field can be edited, but
+      // push nothing to the domain until it is valid again.
+      if (!Number.isFinite(num)) {
+        setDisplay(target.value);
+        return;
+      }
+      commit(num);
+    },
+    [commit]
+  );
+
+  const onBlur = useCallback(
+    ({ target }: InputEvent) => {
+      const num = parseInt(target.value);
+      // Empty/invalid on blur recovers per strategy; otherwise commit as typed.
+      commit(Number.isFinite(num) ? num : resetTo === 'min' ? min : parseInt(lastValid.current));
+    },
+    [commit, min, resetTo]
+  );
+
+  return { value: display, onChange, onBlur };
+};


### PR DESCRIPTION
> Stacked on #36 (#28). Base will retarget to `master` once #36 merges.

## What

Puts the duplicated numeric-input logic behind one hook, `useClampedNumberInput`, so the Count and Timer controls stop reimplementing parse/clamp/reset. Implements #29 (child of PRD #25).

## Interface

`useClampedNumberInput({ value, min, max, onValue, resetTo })` → `{ value, onChange, onBlur }` to spread onto a native `<input>`.

- Owns parse, clamp to `[min, max]`, the display-string state (field can go transiently empty — the mobile stuck-`0` fix), and the blur reset.
- `resetTo: 'last-valid' | 'min'` — the single axis of variation. Count uses `last-valid`, Timer uses `min`.
- Emits only valid, clamped numbers via `onValue`, so an empty field no longer pushes `NaN` into the session.
- Takes the controlled `value` (added beyond the issue's literal interface) so Count still reflects an external session-count change — e.g. a filter lowering the maximum clamps count 12 → 7. Timer passes a static `0` and owns its value locally.

## Result

Count and Timer are now pure render over the hook — no bespoke parse/clamp, and the triplicated `InputEvent` type is gone.

## Tests

`useClampedNumberInput.test.ts` (10 tests): both clamp bounds, both `resetTo` strategies, the empty-field no-emit behaviour, external-value sync, and the timer-style static-value contract. Full suite: 41 passing; `tsc`, `eslint`, `vite build` clean.

Closes #29