### PR TITLE
feat: interval spelling engine (Note ±2, Interval registry, transpose/simplify)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,3 +29,11 @@ The sequence of notes each a fifth apart. One basis for a Filter.
 
 **Inversion Group**:
 A cluster of notes treated as related for inversion practice (e.g. C/F/G). One basis for a Filter.
+
+**Interval**:
+The distance between two Notes, named by its number and quality (e.g. major 3rd, tritone). Modelled as a letter-step count plus a semitone count, so its spelling is theory-correct. One of an ordered registry, parallel to Filter.
+_Avoid_: gap, distance, step.
+
+**Root**:
+The Note an Interval is measured from — the question in interval practice; transposing it by an Interval gives the answer Note.
+_Avoid_: start note, base, origin.

--- a/docs/adr/0005-hybrid-interval-spelling.md
+++ b/docs/adr/0005-hybrid-interval-spelling.md
@@ -1,0 +1,36 @@
+# Interval spelling is theory-correct in the domain, simplified only for display
+
+Interval practice asks "what note is a given interval above a Root?". A
+given pitch has several enharmonic names (F♯ = G♭), and the *correct* answer
+depends on the interval's spelling: a tritone above C spelled as an augmented
+4th is F♯, spelled as a diminished 5th it is G♭. Computing the answer by pitch
+alone loses this — and iteratively re-spelling to "look nice" is where naive
+implementations get intervals wrong.
+
+**Decision:** split the two concerns.
+
+- `transpose(note, interval)` is the **source of truth**. The answer letter is
+  the Root letter advanced by the interval's `letterSteps`; the accidental
+  offset is then whatever hits the target pitch class. This is theory-correct
+  and may return **double accidentals** — the major 7th above G♯ is F𝄪, not G.
+  The `Interval` registry encodes each interval as `(letterSteps, semitones)`,
+  so the tritone is modelled as an augmented 4th (`letterSteps` 3) and spells
+  F♯ from C, never G♭.
+- `simplify(note)` is **for display only**. It maps any Note — including
+  doubles — to its enharmonic-simplest name (0–1 accidental) via a fixed
+  pitch-class → name table. It preserves pitch, never spelling.
+
+This is the "hybrid spelling" design: keep the theory-correct note internally,
+show the readable one. The ADR-0004 signed `offset` representation is what makes
+the double-accidental range a one-line widening (`-1..+1` → `-2..+2`).
+
+**Why not simplify eagerly (store only simplified notes)?** Then the domain
+could no longer distinguish an augmented 4th from a diminished 5th, and interval
+answers would be wrong for exactly the cases that make interval practice worth
+doing. The double accidental is a feature of correctness, not a defect to be
+normalised away.
+
+**Note for future readers:** never route `transpose` output through `simplify`
+before comparing or storing it — `simplify` is a render-leaf concern, the same
+way `Note.format` is. Comparisons and further transposition use the
+theory-correct value.

--- a/src/interval.test.ts
+++ b/src/interval.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { INTERVALS, simplify, transpose, type IntervalName } from './interval';
+import { flat, format, natural, pitchClass, sharp, type Note } from './note';
+import type { NoteLetter } from './consts';
+
+const by = (name: IntervalName) => INTERVALS.find((i) => i.name === name)!;
+
+describe('Interval registry', () => {
+  it('lists the nine ascending intervals in order', () => {
+    expect(INTERVALS.map((i) => i.name)).toEqual([
+      'minor 3rd',
+      'major 3rd',
+      '4th',
+      'tritone',
+      '5th',
+      'minor 6th',
+      'major 6th',
+      'minor 7th',
+      'major 7th',
+    ]);
+  });
+
+  it('pairs each interval with its letter-step and semitone counts', () => {
+    expect(INTERVALS.map((i) => [i.letterSteps, i.semitones])).toEqual([
+      [2, 3],
+      [2, 4],
+      [3, 5],
+      [3, 6],
+      [4, 7],
+      [5, 8],
+      [5, 9],
+      [6, 10],
+      [6, 11],
+    ]);
+  });
+
+  it('models the tritone as an augmented 4th (letterSteps 3)', () => {
+    const tritone = INTERVALS.find((i) => i.name === 'tritone');
+    expect(tritone?.letterSteps).toBe(3);
+  });
+});
+
+describe('transpose (theory-correct spelling)', () => {
+  const cases: [Note, IntervalName, string][] = [
+    // Every interval from C — hand-authored so each interval's letter advance
+    // and accidental is pinned by an independent theory value, not the impl.
+    [natural('C'), 'minor 3rd', 'E♭'],
+    [natural('C'), 'major 3rd', 'E'],
+    [natural('C'), '4th', 'F'],
+    [natural('C'), 'tritone', 'F♯'], // augmented 4th, not G♭
+    [natural('C'), '5th', 'G'],
+    [natural('C'), 'minor 6th', 'A♭'],
+    [natural('C'), 'major 6th', 'A'],
+    [natural('C'), 'minor 7th', 'B♭'],
+    [natural('C'), 'major 7th', 'B'],
+    // Other starts, including accidental and double-accidental answers.
+    [natural('B'), 'minor 3rd', 'D'],
+    [natural('B'), '5th', 'F♯'],
+    [sharp('G'), 'major 7th', 'F𝄪'], // double sharp
+    [flat('B'), '5th', 'F'],
+  ];
+
+  it.each(cases)('%o + %s = %s', (root, name, expected) => {
+    expect(format(transpose(root, by(name)))).toBe(expected);
+  });
+
+  it('advances the answer letter by the interval letter-steps', () => {
+    // tritone from C advances 3 letters: C -> F (spelled F♯, not G♭)
+    expect(transpose(natural('C'), by('tritone')).letter).toBe('F');
+  });
+});
+
+describe('simplify (enharmonic-simplest display name)', () => {
+  const cases: [Note, string][] = [
+    [{ letter: 'F', offset: 2 }, 'G'], // F𝄪 -> G
+    [{ letter: 'B', offset: -2 }, 'A'], // B𝄫 -> A
+    [flat('C'), 'B'], // C♭ -> B
+    [sharp('E'), 'F'], // E♯ -> F
+    [natural('C'), 'C'], // already simplest
+    [sharp('C'), 'C♯'], // single accidental stays single
+  ];
+
+  it.each(cases)('%o -> %s', (note, expected) => {
+    expect(format(simplify(note))).toBe(expected);
+  });
+
+  it('never returns more than a single accidental', () => {
+    const doubles: Note[] = [
+      { letter: 'F', offset: 2 },
+      { letter: 'B', offset: -2 },
+      { letter: 'C', offset: 2 },
+      { letter: 'A', offset: -2 },
+    ];
+    for (const note of doubles) {
+      expect(Math.abs(simplify(note).offset)).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('preserves the minor quality', () => {
+    expect(format(simplify({ letter: 'F', offset: 2, quality: 'minor' }))).toBe('Gm');
+  });
+});
+
+describe('exhaustive: every single-accidental root x every interval', () => {
+  // The musical alphabet as an independent source of truth for letter advance.
+  const ALPHABET: NoteLetter[] = ['A', 'B', 'C', 'D', 'E', 'F', 'G'];
+  const ROOTS: Note[] = ALPHABET.flatMap((letter) => [
+    flat(letter),
+    natural(letter),
+    sharp(letter),
+  ]);
+
+  it.each(ROOTS)('%o transposes and simplifies correctly across all intervals', (root) => {
+    for (const interval of INTERVALS) {
+      const result = transpose(root, interval);
+
+      // Letter advances by the interval's letter-steps along the alphabet.
+      const expectedLetter =
+        ALPHABET[(ALPHABET.indexOf(root.letter) + interval.letterSteps) % 7];
+      expect(result.letter).toBe(expectedLetter);
+
+      // The answer sounds the theory-correct pitch...
+      expect(pitchClass(result)).toBe((pitchClass(root) + interval.semitones) % 12);
+      // ...within a double accidental at most.
+      expect(Math.abs(result.offset)).toBeLessThanOrEqual(2);
+
+      // simplify keeps the pitch but never exceeds a single accidental.
+      const simple = simplify(result);
+      expect(pitchClass(simple)).toBe(pitchClass(result));
+      expect(Math.abs(simple.offset)).toBeLessThanOrEqual(1);
+    }
+  });
+});

--- a/src/interval.ts
+++ b/src/interval.ts
@@ -1,0 +1,80 @@
+import { natural, pitchClass, type Note, type Offset } from './note';
+import { NATURAL_NOTES } from './consts';
+
+// The musical alphabet in order, used to advance the answer letter by an
+// interval's letter-steps (wrapping A→G→A). This is the natural-note sequence.
+const LETTERS = NATURAL_NOTES;
+
+// Fold a raw semitone difference into the nearest signed offset. A properly
+// paired interval (matched letterSteps/semitones) always lands within ±2; the
+// window is (-6, 6] so a mispaired row surfaces as an out-of-range value that
+// `transpose` rejects rather than silently mis-spelling.
+const normalizeOffset = (diff: number): number => {
+  const d = ((diff % 12) + 12) % 12;
+  return d > 6 ? d - 12 : d;
+};
+
+// An ascending interval. `letterSteps` is how far the answer letter advances
+// along the musical alphabet (a 3rd advances 2 letters); `semitones` is the
+// chromatic distance. The pair fixes the theory-correct spelling — the tritone
+// is an augmented 4th (letterSteps 3), so from C it spells F♯, not G♭.
+export type Interval = {
+  name: string;
+  letterSteps: number;
+  semitones: number;
+};
+
+// Ordered registry (same single-source-of-truth pattern as the note-set Filter
+// registry): adding or reordering an interval is a single edit here.
+export const INTERVALS = [
+  { name: 'minor 3rd', letterSteps: 2, semitones: 3 },
+  { name: 'major 3rd', letterSteps: 2, semitones: 4 },
+  { name: '4th', letterSteps: 3, semitones: 5 },
+  { name: 'tritone', letterSteps: 3, semitones: 6 },
+  { name: '5th', letterSteps: 4, semitones: 7 },
+  { name: 'minor 6th', letterSteps: 5, semitones: 8 },
+  { name: 'major 6th', letterSteps: 5, semitones: 9 },
+  { name: 'minor 7th', letterSteps: 6, semitones: 10 },
+  { name: 'major 7th', letterSteps: 6, semitones: 11 },
+] as const satisfies readonly Interval[];
+
+export type IntervalName = (typeof INTERVALS)[number]['name'];
+
+// The theory-correct answer note an interval above `root`. The answer letter
+// advances by `letterSteps`; its accidental offset is whatever hits the target
+// pitch class — which may be a double accidental (major 7th above G♯ = F𝄪).
+// Source of truth for spelling; `simplify` is for display.
+export const transpose = (root: Note, interval: Interval): Note => {
+  const letter = LETTERS[(LETTERS.indexOf(root.letter) + interval.letterSteps) % 7];
+  const targetPitch = (pitchClass(root) + interval.semitones) % 12;
+  const offset = normalizeOffset(targetPitch - pitchClass(natural(letter)));
+  // Guards the `as Offset` cast: a proper interval never exceeds a double
+  // accidental, so an out-of-range value means a bad registry row, not input.
+  if (offset < -2 || offset > 2) {
+    throw new Error(`Interval ${interval.name} produced an out-of-range offset ${offset}`);
+  }
+  return { letter, offset: offset as Offset };
+};
+
+// The enharmonic-simplest spelling (0-1 accidental) for each pitch class.
+const SIMPLEST: Omit<Note, 'quality'>[] = [
+  { letter: 'C', offset: 0 }, // 0
+  { letter: 'C', offset: 1 }, // 1  C♯
+  { letter: 'D', offset: 0 }, // 2
+  { letter: 'E', offset: -1 }, // 3  E♭
+  { letter: 'E', offset: 0 }, // 4
+  { letter: 'F', offset: 0 }, // 5
+  { letter: 'F', offset: 1 }, // 6  F♯
+  { letter: 'G', offset: 0 }, // 7
+  { letter: 'A', offset: -1 }, // 8  A♭
+  { letter: 'A', offset: 0 }, // 9
+  { letter: 'B', offset: -1 }, // 10 B♭
+  { letter: 'B', offset: 0 }, // 11
+];
+
+// Re-spell any note (including double accidentals) as its enharmonic-simplest
+// name for display. Quality is orthogonal to pitch, so it is carried through.
+export const simplify = (note: Note): Note => ({
+  ...SIMPLEST[pitchClass(note)],
+  ...(note.quality ? { quality: note.quality } : {}),
+});

--- a/src/note.test.ts
+++ b/src/note.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { flat, format, natural, pitchClass, sharp, type Note } from './note';
+
+describe('format accidental glyphs', () => {
+  it('renders single accidentals and naturals as before', () => {
+    expect(format(natural('A'))).toBe('A');
+    expect(format(sharp('A'))).toBe('A♯');
+    expect(format(flat('A'))).toBe('A♭');
+  });
+
+  it('renders the minor quality suffix', () => {
+    expect(format({ letter: 'C', offset: 1, quality: 'minor' })).toBe('C♯m');
+  });
+
+  it('renders double accidentals', () => {
+    expect(format({ letter: 'F', offset: 2 })).toBe('F𝄪');
+    expect(format({ letter: 'B', offset: -2 })).toBe('B𝄫');
+  });
+});
+
+describe('pitchClass', () => {
+  it('returns the chromatic pitch class 0-11 for naturals', () => {
+    // C=0, D=2, E=4, F=5, G=7, A=9, B=11
+    const expected: Record<string, number> = {
+      C: 0,
+      D: 2,
+      E: 4,
+      F: 5,
+      G: 7,
+      A: 9,
+      B: 11,
+    };
+    for (const [letter, pc] of Object.entries(expected)) {
+      expect(pitchClass(natural(letter as Note['letter']))).toBe(pc);
+    }
+  });
+
+  it('applies the accidental offset, wrapping into 0-11', () => {
+    expect(pitchClass(sharp('C'))).toBe(1);
+    expect(pitchClass(flat('C'))).toBe(11); // C♭ = B
+    expect(pitchClass(sharp('B'))).toBe(0); // B♯ = C
+    expect(pitchClass({ letter: 'F', offset: 2 })).toBe(7); // F𝄪 = G
+    expect(pitchClass({ letter: 'B', offset: -2 })).toBe(9); // B𝄫 = A
+  });
+});

--- a/src/note.ts
+++ b/src/note.ts
@@ -1,11 +1,10 @@
 import type { NoteLetter } from './consts';
 
 // A structured note value. `offset` is a signed semitone offset from the
-// natural letter (♭ = -1, ♮ = 0, ♯ = +1). Note practice only ever uses
-// -1 | 0 | 1; the signed representation lets interval practice later widen
-// the range to double accidentals (see #31) as a one-line change rather than
-// a representation migration.
-export type Offset = -1 | 0 | 1;
+// natural letter (𝄫 = -2, ♭ = -1, ♮ = 0, ♯ = +1, 𝄪 = +2). Note practice only
+// ever uses -1 | 0 | 1; interval practice (#31) widens the range to double
+// accidentals for theory-correct transposition (see ADR-0004, ADR-0005).
+export type Offset = -2 | -1 | 0 | 1 | 2;
 
 export type Note = {
   letter: NoteLetter;
@@ -20,8 +19,32 @@ export const sharp = (letter: NoteLetter): Note => ({ letter, offset: 1 });
 export const flat = (letter: NoteLetter): Note => ({ letter, offset: -1 });
 export const minor = (note: Note): Note => ({ ...note, quality: 'minor' });
 
-const ACCIDENTAL: Record<Offset, string> = { [-1]: '♭', [0]: '', [1]: '♯' };
+// A natural note renders as the bare letter (offset 0 → ''), so the ♮ sign is
+// never emitted for a standalone note — this keeps note-practice display
+// unchanged while the double accidentals 𝄫/𝄪 support interval answers.
+const ACCIDENTAL: Record<Offset, string> = {
+  [-2]: '𝄫',
+  [-1]: '♭',
+  [0]: '',
+  [1]: '♯',
+  [2]: '𝄪',
+};
 
-// Rendered form, e.g. 'A', 'A♯', 'A♭', 'Am', 'A♯m'. Called only at the render leaf.
+// Rendered form, e.g. 'A', 'A♯', 'A♭', 'Am', 'F𝄪'. Called only at the render leaf.
 export const format = (note: Note): string =>
   `${note.letter}${ACCIDENTAL[note.offset]}${note.quality === 'minor' ? 'm' : ''}`;
+
+// Semitones above C for each natural letter.
+const LETTER_SEMITONES: Record<NoteLetter, number> = {
+  C: 0,
+  D: 2,
+  E: 4,
+  F: 5,
+  G: 7,
+  A: 9,
+  B: 11,
+};
+
+// The chromatic pitch class (0-11) a note sounds, folding the accidental in.
+export const pitchClass = (note: Note): number =>
+  (((LETTER_SEMITONES[note.letter] + note.offset) % 12) + 12) % 12;


### PR DESCRIPTION
Implements #31 — the pure-domain half of interval practice (parent #30). No UI, no randomness; verified entirely by tests.

## What's here
- **Note module deepened** (`note.ts`): accidental `offset` widened `-1..+1` → `-2..+2` with double-accidental glyphs (𝄫/𝄪); added `pitchClass(note)` → 0–11. A natural (offset 0) still renders as the bare letter — ♮ is redundant and intentionally never emitted, so note-practice display is unchanged.
- **Interval registry** (`interval.ts`): nine-entry ordered registry `{ name, letterSteps, semitones }`; the tritone is modelled as an augmented 4th (letterSteps 3), so it spells F♯ from C, not G♭.
- **`transpose(root, interval)`**: theory-correct answer Note. Advances the letter by `letterSteps`, sets the accidental to hit the semitone target — may return double accidentals (major 7th above G♯ = F𝄪). Guards its `Offset` cast against a mispaired registry row.
- **`simplify(note)`**: maps any Note (including doubles) to its enharmonic-simplest name (0–1 accidental) via a fixed pitch-class → name table; preserves quality.
- **ADR-0005**: hybrid spelling — theory-correct domain, simplified display.
- **CONTEXT.md**: added `Interval` and `Root` to the glossary.

## Tests
TDD, one seam at a time. 72 pass; `tsc` and `eslint` clean.
- Exhaustive sweep: 21 single-accidental roots × 9 intervals asserting letter advance, pitch class, `offset ≤ ±2`, and `simplify` ≤ ±1 accidental.
- All nine intervals from C hand-authored as independent literal spellings; double-accidental case (G♯ major 7th = F𝄪) pinned.
- No `Random` dependency — `transpose`/`simplify`/`pitchClass` are deterministic.

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)