### PR TITLE
feat: interval practice mode (mode switch, useIntervalSession, prompt/reveal UI)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -37,3 +37,27 @@ _Avoid_: gap, distance, step.
 **Root**:
 The Note an Interval is measured from — the question in interval practice; transposing it by an Interval gives the answer Note.
 _Avoid_: start note, base, origin.
+
+**Challenge**:
+One interval-practice question: a Root plus an Interval. Shown as a prompt; tapping reveals its answer Note, tapping again draws the next. The interval-mode counterpart of a Note Set.
+_Avoid_: question, card, problem.
+
+**Practice mode**:
+Which drill the app is running — note practice or interval practice — chosen from the top-level switch. Each mode has its own session; the shell hosts whichever is active.
+_Avoid_: screen, tab, page, view.
+
+**Offset**:
+A Note's accidental as a signed semitone shift from its natural letter: 𝄫 −2, ♭ −1, ♮ 0, ♯ +1, 𝄪 +2. Note practice uses only −1..+1; interval answers may reach ±2.
+_Avoid_: accidental value, shift amount.
+
+**Pitch class**:
+The 0–11 chromatic value a Note sounds (letter + offset, mod 12). Enharmonic Notes share a pitch class (A♯ and B♭ are both 10).
+_Avoid_: pitch, semitone, tone.
+
+**Transpose**:
+Compute the theory-correct answer Note an Interval above a Root — the answer's letter is advanced by the Interval's letter-steps, its offset set to hit the semitone count. The domain's source of truth; may yield a double accidental.
+_Avoid_: shift, move, add.
+
+**Simplify**:
+Re-spell any Note as its enharmonic-simplest name (0–1 accidental) for display. Never the source of truth — a render-leaf concern, like formatting. See ADR-0005.
+_Avoid_: normalise, reduce, resolve.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,30 +1,20 @@
-import { Notes } from './components/Notes';
-import { Settings } from './components/Settings';
-import { usePracticeSession } from './usePracticeSession';
+import { useState } from 'react';
+
+import { IntervalPractice } from './components/IntervalPractice';
+import { ModeSwitch, type PracticeMode } from './components/ModeSwitch';
+import { NotePractice } from './components/NotePractice';
 
 const App = () => {
-  const { notes, filter, setFilter, count, setCount, maxCount, setTimerSeconds, refresh } =
-    usePracticeSession();
+  const [mode, setMode] = useState<PracticeMode>('notes');
+  const header = <ModeSwitch mode={mode} setMode={setMode} />;
 
-  return (
-    <div className="flex flex-col h-dvh bg-gray-900">
-      <div className="flex-1 w-full max-w-6xl p-4 mx-auto select-none" onClick={refresh}>
-        <Notes notes={notes} />
-      </div>
-      <div className="my-4 text-sm italic text-center text-gray-100 opacity-25">
-        Tap screen to refresh notes
-      </div>
-      <div className="grid grid-rows-3 px-4 pt-4 bg-gray-300 md:grid-cols-3 md:grid-rows-1">
-        <Settings
-          filter={filter}
-          setFilter={setFilter}
-          count={count}
-          maxCount={maxCount}
-          setCount={setCount}
-          setTimerSeconds={setTimerSeconds}
-        />
-      </div>
-    </div>
+  // Only the active mode is mounted, so exactly one session (and its timer)
+  // ever runs — switching modes tears the other down rather than leaving it
+  // ticking in the background.
+  return mode === 'intervals' ? (
+    <IntervalPractice header={header} />
+  ) : (
+    <NotePractice header={header} />
   );
 };
 

--- a/src/components/IntervalChallenge.tsx
+++ b/src/components/IntervalChallenge.tsx
@@ -1,0 +1,38 @@
+import { FC } from 'react';
+
+import { NOTE_COLORS } from '../consts';
+import { format, type Note } from '../note';
+import type { Challenge } from '../useIntervalSession';
+import { NoteView } from './Notes';
+
+// Prompt shows the Root and Interval name for a cold attempt. On reveal it shows
+// the simplified answer prominently, with the theory-correct spelling as a small
+// caption — and only when it differs (e.g. F𝄪 vs G), since an identical caption
+// would be redundant.
+export const IntervalChallenge: FC<{
+  challenge: Challenge;
+  revealed: boolean;
+  answer: Note;
+  simplified: Note;
+}> = ({ challenge, revealed, answer, simplified }) => {
+  const { root, interval } = challenge;
+  const spellingDiffers = format(simplified) !== format(answer);
+
+  return (
+    <div className="flex flex-col items-center content-center justify-center h-full gap-8">
+      <div className="flex flex-wrap items-center justify-center gap-4">
+        <NoteView colorClass={NOTE_COLORS[root.letter]} text={format(root)} />
+        <span className="text-2xl italic text-gray-400 md:text-4xl">{interval.name}</span>
+      </div>
+
+      {revealed && (
+        <div className="flex flex-col items-center gap-2">
+          <NoteView colorClass={NOTE_COLORS[simplified.letter]} text={format(simplified)} />
+          {spellingDiffers && (
+            <span className="text-sm text-gray-400">spelled {format(answer)}</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/components/IntervalPractice.tsx
+++ b/src/components/IntervalPractice.tsx
@@ -1,0 +1,34 @@
+import { FC, ReactNode } from 'react';
+
+import { useIntervalSession } from '../useIntervalSession';
+import { IntervalChallenge } from './IntervalChallenge';
+import { IntervalSettings } from './Settings/IntervalSettings';
+import { Shell } from './Shell';
+
+// Interval practice, hosted in the shared Shell. Mounted only while active, so
+// its session (and auto-advance timer) exists only then.
+export const IntervalPractice: FC<{ header: ReactNode }> = ({ header }) => {
+  const session = useIntervalSession();
+
+  return (
+    <Shell
+      header={header}
+      onAdvance={session.advance}
+      hint={session.revealed ? 'Tap for the next challenge' : 'Tap to reveal the answer'}
+      settings={
+        <IntervalSettings
+          enabledIntervalNames={session.enabledIntervalNames}
+          toggleInterval={session.toggleInterval}
+          setTimerSeconds={session.setTimerSeconds}
+        />
+      }
+    >
+      <IntervalChallenge
+        challenge={session.challenge}
+        revealed={session.revealed}
+        answer={session.answer}
+        simplified={session.simplified}
+      />
+    </Shell>
+  );
+};

--- a/src/components/ModeSwitch.tsx
+++ b/src/components/ModeSwitch.tsx
@@ -1,0 +1,31 @@
+import { FC } from 'react';
+
+// The practice modes. Application state; adding a third mode means an entry
+// here, its own `*Practice` component (session + view), and a branch in App.
+export type PracticeMode = 'notes' | 'intervals';
+
+const MODES: { value: PracticeMode; label: string }[] = [
+  { value: 'notes', label: 'Notes' },
+  { value: 'intervals', label: 'Intervals' },
+];
+
+export const ModeSwitch: FC<{
+  mode: PracticeMode;
+  setMode: (mode: PracticeMode) => void;
+}> = ({ mode, setMode }) => (
+  <div className="inline-flex overflow-hidden border border-gray-400 rounded" role="group">
+    {MODES.map(({ value, label }) => (
+      <button
+        key={value}
+        type="button"
+        aria-pressed={mode === value}
+        onClick={() => setMode(value)}
+        className={`px-3 py-1 ${
+          mode === value ? 'bg-gray-700 text-white' : 'bg-white text-gray-700'
+        }`}
+      >
+        {label}
+      </button>
+    ))}
+  </div>
+);

--- a/src/components/NotePractice.tsx
+++ b/src/components/NotePractice.tsx
@@ -1,0 +1,34 @@
+import { FC, ReactNode } from 'react';
+
+import { usePracticeSession } from '../usePracticeSession';
+import { Notes } from './Notes';
+import { Settings } from './Settings';
+import { Shell } from './Shell';
+
+// Note practice: the original drill, now hosted in the shared Shell. Mounted
+// only while active, so its session (and auto-refresh timer) exists only then.
+export const NotePractice: FC<{ header: ReactNode }> = ({ header }) => {
+  const session = usePracticeSession();
+
+  return (
+    <Shell
+      header={header}
+      onAdvance={session.refresh}
+      hint="Tap screen to refresh notes"
+      settings={
+        <div className="grid grid-rows-3 px-4 pt-4 md:grid-cols-3 md:grid-rows-1">
+          <Settings
+            filter={session.filter}
+            setFilter={session.setFilter}
+            count={session.count}
+            maxCount={session.maxCount}
+            setCount={session.setCount}
+            setTimerSeconds={session.setTimerSeconds}
+          />
+        </div>
+      }
+    >
+      <Notes notes={session.notes} />
+    </Shell>
+  );
+};

--- a/src/components/Settings/IntervalSettings.tsx
+++ b/src/components/Settings/IntervalSettings.tsx
@@ -1,0 +1,19 @@
+import { FC } from 'react';
+
+import type { IntervalName } from '../../interval';
+
+import { IntervalSubset } from './IntervalSubset';
+import { Timer } from './Timer';
+
+// The interval-mode settings row: the interval-subset selector and the shared
+// Timer. No Count in this mode. Parallel to the note-practice Settings.
+export const IntervalSettings: FC<{
+  enabledIntervalNames: IntervalName[];
+  toggleInterval: (name: IntervalName) => void;
+  setTimerSeconds: (seconds: number | null) => void;
+}> = ({ enabledIntervalNames, toggleInterval, setTimerSeconds }) => (
+  <div className="flex flex-col items-center gap-4 px-4 pt-4 md:flex-row md:justify-between">
+    <IntervalSubset enabled={enabledIntervalNames} toggle={toggleInterval} />
+    <Timer onValue={setTimerSeconds} />
+  </div>
+);

--- a/src/components/Settings/IntervalSubset.tsx
+++ b/src/components/Settings/IntervalSubset.tsx
@@ -1,0 +1,24 @@
+import { FC } from 'react';
+
+import { INTERVALS, type IntervalName } from '../../interval';
+
+// The interval-subset selector: the nine intervals as toggles, parallel to the
+// Filter dropdown. Disabling an interval removes it from challenge generation.
+export const IntervalSubset: FC<{
+  enabled: IntervalName[];
+  toggle: (name: IntervalName) => void;
+}> = ({ enabled, toggle }) => (
+  <fieldset className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1">
+    <legend className="mb-1 text-gray-400">Intervals</legend>
+    {INTERVALS.map(({ name }) => (
+      <label key={name} className="flex items-center gap-1 text-gray-700">
+        <input
+          type="checkbox"
+          checked={enabled.includes(name)}
+          onChange={() => toggle(name)}
+        />
+        {name}
+      </label>
+    ))}
+  </fieldset>
+);

--- a/src/components/Shell.tsx
+++ b/src/components/Shell.tsx
@@ -1,0 +1,22 @@
+import { FC, ReactNode } from 'react';
+
+// The generic shell hosting whichever practice mode is active: the mode switch,
+// the full-height tap area, the tap hint, and the settings bar. Both a tap and
+// (inside each session) a timer tick drive the active session's advance(); the
+// shell wires the tap. Mode-specific content and controls come in as slots.
+export const Shell: FC<{
+  header: ReactNode; // mode switch
+  onAdvance: () => void;
+  hint: string;
+  settings: ReactNode;
+  children: ReactNode; // tap-area content
+}> = ({ header, onAdvance, hint, settings, children }) => (
+  <div className="flex flex-col h-dvh bg-gray-900">
+    <div className="flex justify-center p-2 bg-gray-800">{header}</div>
+    <div className="flex-1 w-full max-w-6xl p-4 mx-auto select-none" onClick={onAdvance}>
+      {children}
+    </div>
+    <div className="my-4 text-sm italic text-center text-gray-100 opacity-25">{hint}</div>
+    <div className="bg-gray-300">{settings}</div>
+  </div>
+);

--- a/src/timerDelay.ts
+++ b/src/timerDelay.ts
@@ -1,0 +1,6 @@
+// seconds -> interval delay in ms, or null to pause. Zero, negative, or
+// non-numeric input all pause the timer. Shared by every practice session.
+export const secondsToDelay = (seconds: number | null): number | null => {
+  if (seconds === null || !Number.isFinite(seconds) || seconds <= 0) return null;
+  return seconds * 1000;
+};

--- a/src/useAutoAdvanceTimer.ts
+++ b/src/useAutoAdvanceTimer.ts
@@ -1,0 +1,28 @@
+import { useCallback, useState } from 'react';
+
+import { secondsToDelay } from './timerDelay';
+
+export type AutoAdvanceTimer = {
+  delay: number | null; // ms between ticks, or null to pause
+  nonce: number; // bump to restart the interval
+  setTimerSeconds: (seconds: number | null) => void;
+  reset: () => void;
+};
+
+// The auto-advance timer shared by every practice session: a delay (ms, or null
+// to pause) plus a nonce that restarts the interval on demand — the hidden
+// reset-on-advance. Pair it with `useInterval(advance, delay, nonce)` at the
+// call site and call `reset()` whenever `advance` runs, so a manual tap starts
+// the countdown over.
+export const useAutoAdvanceTimer = (): AutoAdvanceTimer => {
+  const [delay, setDelay] = useState<number | null>(null);
+  const [nonce, setNonce] = useState(0);
+
+  const setTimerSeconds = useCallback(
+    (seconds: number | null) => setDelay(secondsToDelay(seconds)),
+    []
+  );
+  const reset = useCallback(() => setNonce((n) => n + 1), []);
+
+  return { delay, nonce, setTimerSeconds, reset };
+};

--- a/src/useIntervalSession.test.ts
+++ b/src/useIntervalSession.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { act, renderHook } from '@testing-library/react';
+
+import { useIntervalSession } from './useIntervalSession';
+import { createRandom, type Random } from './random';
+import { INTERVALS } from './interval';
+import { format, type Note } from './note';
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+// Stable rng instance whose stream advances across renders (see usePracticeSession.test).
+const renderSession = (rng: Random) => renderHook(() => useIntervalSession(rng));
+
+// One full challenge cycle: reveal, then draw the next.
+const nextChallenge = (result: { current: { advance: () => void } }) => {
+  act(() => result.current.advance());
+  act(() => result.current.advance());
+};
+
+describe('useIntervalSession — initial state', () => {
+  it('starts hidden with a challenge drawn from the enabled intervals', () => {
+    const { result } = renderSession(createRandom(1));
+
+    expect(result.current.revealed).toBe(false);
+    expect(INTERVALS).toContainEqual(result.current.challenge.interval);
+    expect('letter' in result.current.challenge.root).toBe(true);
+  });
+
+  it('enables all nine intervals by default', () => {
+    const { result } = renderSession(createRandom(1));
+    expect(result.current.enabledIntervalNames).toEqual(INTERVALS.map((i) => i.name));
+  });
+});
+
+describe('useIntervalSession — advance is a two-phase machine', () => {
+  it('reveals the answer when hidden, then draws the next challenge when revealed', () => {
+    const { result } = renderSession(createRandom(1));
+    const first = result.current.challenge;
+
+    act(() => result.current.advance()); // hidden -> revealed
+    expect(result.current.revealed).toBe(true);
+    expect(result.current.challenge).toBe(first); // same challenge, now shown
+
+    act(() => result.current.advance()); // revealed -> next, hidden
+    expect(result.current.revealed).toBe(false);
+  });
+});
+
+describe('useIntervalSession — answer wiring', () => {
+  it('exposes the theory-correct answer and its simplified name', () => {
+    // Identity shuffle picks the first option every draw: root C, interval minor 3rd.
+    const stub: Random = { chance: () => false, shuffle: (arr) => arr };
+    const { result } = renderSession(stub);
+
+    expect(result.current.challenge.root).toEqual({ letter: 'C', offset: 0 });
+    expect(result.current.challenge.interval.name).toBe('minor 3rd');
+    // A minor 3rd above C is E♭ — theory truth, not recomputed from the impl.
+    expect(format(result.current.answer)).toBe('E♭');
+    expect(format(result.current.simplified)).toBe('E♭');
+  });
+});
+
+describe('useIntervalSession — deterministic generation', () => {
+  const collectRoots = (seed: number, rounds: number): Note[] => {
+    const { result } = renderSession(createRandom(seed));
+    const roots = [result.current.challenge.root];
+    for (let i = 1; i < rounds; i++) {
+      nextChallenge(result);
+      roots.push(result.current.challenge.root);
+    }
+    return roots;
+  };
+
+  it('produces the same challenge sequence for the same seed', () => {
+    expect(collectRoots(5, 20)).toEqual(collectRoots(5, 20));
+  });
+
+  it('spells black-key roots both ways over many draws', () => {
+    const roots = collectRoots(5, 200);
+    expect(roots.some((r) => r.offset === 1)).toBe(true); // some sharp spelling
+    expect(roots.some((r) => r.offset === -1)).toBe(true); // some flat spelling
+  });
+});
+
+describe('useIntervalSession — interval subset restricts generation', () => {
+  it('never draws a disabled interval', () => {
+    const { result } = renderSession(createRandom(9));
+
+    act(() => result.current.toggleInterval('minor 3rd'));
+    expect(result.current.enabledIntervalNames).not.toContain('minor 3rd');
+
+    for (let i = 0; i < 300; i++) {
+      nextChallenge(result);
+      expect(result.current.challenge.interval.name).not.toBe('minor 3rd');
+    }
+  });
+
+  it('keeps at least one interval enabled', () => {
+    const { result } = renderSession(createRandom(9));
+
+    act(() => {
+      for (const { name } of INTERVALS) result.current.toggleInterval(name);
+    });
+
+    expect(result.current.enabledIntervalNames.length).toBeGreaterThanOrEqual(1);
+  });
+});
+
+describe('useIntervalSession — timer drives advance', () => {
+  it('advances on each interval tick', () => {
+    vi.useFakeTimers();
+    const { result } = renderSession(createRandom(3));
+    expect(result.current.revealed).toBe(false);
+
+    act(() => result.current.setTimerSeconds(2));
+    act(() => vi.advanceTimersByTime(2000));
+
+    expect(result.current.revealed).toBe(true); // tick revealed the answer
+  });
+
+  it('pauses when the timer is set to zero', () => {
+    vi.useFakeTimers();
+    const { result } = renderSession(createRandom(3));
+
+    act(() => result.current.setTimerSeconds(0));
+    act(() => vi.advanceTimersByTime(10000));
+
+    expect(result.current.revealed).toBe(false);
+  });
+});

--- a/src/useIntervalSession.ts
+++ b/src/useIntervalSession.ts
@@ -1,0 +1,114 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { INTERVALS, simplify, transpose, type Interval, type IntervalName } from './interval';
+import { flat, natural, sharp, type Note } from './note';
+import { defaultRandom, type Random } from './random';
+import { useAutoAdvanceTimer } from './useAutoAdvanceTimer';
+import { useInterval } from './useInterval';
+
+// A Challenge is what interval practice asks: an interval above a Root Note.
+export type Challenge = {
+  root: Note;
+  interval: Interval;
+};
+
+// The single-accidental spelling(s) of each pitch class, in Root order. White
+// keys have one natural spelling; black keys carry both names so a Root can be
+// read either way (e.g. G♯ or A♭).
+const ROOT_SPELLINGS: Note[][] = [
+  [natural('C')],
+  [sharp('C'), flat('D')],
+  [natural('D')],
+  [sharp('D'), flat('E')],
+  [natural('E')],
+  [natural('F')],
+  [sharp('F'), flat('G')],
+  [natural('G')],
+  [sharp('G'), flat('A')],
+  [natural('A')],
+  [sharp('A'), flat('B')],
+  [natural('B')],
+];
+
+// A single random choice from `arr`, drawn through the injected Random so the
+// draw is deterministic under a seed (Random exposes only chance/shuffle).
+const pick = <T>(rng: Random, arr: T[]): T => rng.shuffle(arr)[0];
+
+// Draw a Root: pick one of the twelve pitch classes, then — for a black key —
+// pick one of its two spellings. Both draws go through the Random.
+const drawRoot = (rng: Random): Note => pick(rng, pick(rng, ROOT_SPELLINGS));
+
+const drawChallenge = (rng: Random, intervals: Interval[]): Challenge => ({
+  root: drawRoot(rng),
+  interval: pick(rng, intervals),
+});
+
+export type IntervalSession = {
+  challenge: Challenge;
+  revealed: boolean;
+  answer: Note; // theory-correct spelling (may be a double accidental)
+  simplified: Note; // enharmonic-simplest name, for prominent display
+  enabledIntervalNames: IntervalName[];
+  toggleInterval: (name: IntervalName) => void;
+  setTimerSeconds: (seconds: number | null) => void;
+  advance: () => void;
+};
+
+// One DOM-free module owning the whole interval-practice session: the current
+// Challenge, the two-phase reveal state, the enabled interval subset, and the
+// auto-advance timer. Parallel to usePracticeSession. Randomness is injected and
+// defaults to production, so the app call site stays argument-free.
+export const useIntervalSession = (rng: Random = defaultRandom): IntervalSession => {
+  const [enabled, setEnabled] = useState<Set<IntervalName>>(
+    () => new Set(INTERVALS.map((i) => i.name))
+  );
+  const [challenge, setChallenge] = useState<Challenge>(() => drawChallenge(rng, [...INTERVALS]));
+  const [revealed, setRevealed] = useState(false);
+  const timer = useAutoAdvanceTimer();
+
+  // Enabled intervals in registry order, both as objects (for drawing) and as
+  // names (for the selector).
+  const enabledObjects = useMemo(() => INTERVALS.filter((i) => enabled.has(i.name)), [enabled]);
+  const enabledIntervalNames = useMemo(() => enabledObjects.map((i) => i.name), [enabledObjects]);
+
+  const answer = useMemo(() => transpose(challenge.root, challenge.interval), [challenge]);
+  const simplified = useMemo(() => simplify(answer), [answer]);
+
+  // Two-phase machine: reveal the hidden answer, else draw the next Challenge.
+  // Both a tap and a timer tick call this.
+  const advance = useCallback(() => {
+    if (revealed) {
+      setChallenge(drawChallenge(rng, enabledObjects));
+      setRevealed(false);
+    } else {
+      setRevealed(true);
+    }
+    timer.reset();
+  }, [revealed, rng, enabledObjects, timer]);
+
+  const toggleInterval = useCallback((name: IntervalName) => {
+    setEnabled((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) {
+        // Keep at least one enabled — an empty subset has nothing to draw.
+        if (next.size > 1) next.delete(name);
+      } else {
+        next.add(name);
+      }
+      return next;
+    });
+  }, []);
+
+  useInterval(advance, timer.delay, timer.nonce);
+
+  return {
+    challenge,
+    revealed,
+    answer,
+    simplified,
+    enabledIntervalNames,
+    toggleInterval,
+    setTimerSeconds: timer.setTimerSeconds,
+    advance,
+  };
+};

--- a/src/usePracticeSession.ts
+++ b/src/usePracticeSession.ts
@@ -5,6 +5,7 @@ import { DEFAULT_NOTES_FILTER, getNotes, type NoteSetFilter } from './noteSets';
 import { defaultRandom, type Random } from './random';
 import type { Note } from './note';
 import { useInterval } from './useInterval';
+import { useAutoAdvanceTimer } from './useAutoAdvanceTimer';
 
 // The maximum notes a filter can offer: naturals is a seven-note octave,
 // every other filter is a full twelve.
@@ -13,13 +14,6 @@ const maxCountFor = (filter: NoteSetFilter): number =>
 
 const clamp = (value: number, min: number, max: number): number =>
   Math.min(Math.max(value, min), max);
-
-// seconds -> interval delay in ms, or null to pause. Zero, negative, or
-// non-numeric input all pause the timer.
-const secondsToDelay = (seconds: number | null): number | null => {
-  if (seconds === null || !Number.isFinite(seconds) || seconds <= 0) return null;
-  return seconds * 1000;
-};
 
 export type PracticeSession = {
   notes: Note[];
@@ -43,10 +37,7 @@ export const usePracticeSession = (rng: Random = defaultRandom): PracticeSession
   const [notes, setNotes] = useState<Note[]>(() =>
     getNotes({ filter: DEFAULT_NOTES_FILTER, count: DEFAULT_NOTES_COUNT }, rng)
   );
-  // null pauses the timer; a positive number is the auto-refresh delay in ms.
-  const [timerDelay, setTimerDelay] = useState<number | null>(null);
-  // Bumped on every refresh to restart the interval — the hidden reset-on-tap.
-  const [timerNonce, setTimerNonce] = useState(0);
+  const timer = useAutoAdvanceTimer();
 
   const maxCount = maxCountFor(filter);
 
@@ -61,8 +52,8 @@ export const usePracticeSession = (rng: Random = defaultRandom): PracticeSession
 
   const refresh = useCallback(() => {
     regenerate(filter, count);
-    setTimerNonce((nonce) => nonce + 1);
-  }, [filter, count, regenerate]);
+    timer.reset();
+  }, [filter, count, regenerate, timer]);
 
   const setFilter = useCallback(
     (next: NoteSetFilter) => {
@@ -83,11 +74,7 @@ export const usePracticeSession = (rng: Random = defaultRandom): PracticeSession
     [filter, regenerate]
   );
 
-  const setTimerSeconds = useCallback((seconds: number | null) => {
-    setTimerDelay(secondsToDelay(seconds));
-  }, []);
-
-  useInterval(refresh, timerDelay, timerNonce);
+  useInterval(refresh, timer.delay, timer.nonce);
 
   return {
     notes,
@@ -96,7 +83,7 @@ export const usePracticeSession = (rng: Random = defaultRandom): PracticeSession
     count,
     setCount,
     maxCount,
-    setTimerSeconds,
+    setTimerSeconds: timer.setTimerSeconds,
     refresh,
   };
 };


### PR DESCRIPTION
Implements #32 (parent #30) — the end-to-end interval practice experience, built on the #31 spelling engine.

## What's here
- **`useIntervalSession`** — DOM-free hook parallel to `usePracticeSession`, owning the current **Challenge** (Root + Interval), the two-phase reveal state, the enabled interval subset, and the auto-advance timer. Challenge generation draws a Root (all 12 pitch classes; black keys spelled both ways, e.g. G♯ or A♭) and an Interval from the injected `Random`, so a session is deterministic under a seed.
- **`advance()`** — two-phase machine: reveal when hidden, draw the next Challenge when revealed. Both a tap and a timer tick drive it (hands-free drilling).
- **Generic `Shell`** hosts whichever mode is active (layout, tap area, hint, settings). Top-level **`ModeSwitch`** selects Notes / Intervals as app state. Only the active mode is mounted (`NotePractice` / `IntervalPractice`), so exactly one session and timer ever runs — switching tears the other down instead of leaving it ticking.
- **Prompt / reveal** — prompt shows Root + Interval name for a cold attempt; reveal shows the enharmonic-simplest answer prominently plus the theory-correct spelling as a small caption *when it differs* (e.g. B♭ prominent, "spelled A♯"). Notes coloured by letter, as in note practice.
- **Interval-subset selector** over the nine intervals, all enabled by default; disabling removes them from generation (a guard keeps at least one enabled so there's always something to draw).
- Extracted the shared auto-advance timer into **`useAutoAdvanceTimer`** (used by both sessions).
- Added **Challenge, practice mode, offset, pitch class, transpose, simplify** to `CONTEXT.md`.

## Notes-mode behaviour
Unchanged — same session, same controls, now hosted in the Shell.

## Tests
TDD on the `useIntervalSession` seam. 102 pass; `tsc` and `eslint` clean.
- Deterministic challenge generation under a seed, including both-ways black-key spelling.
- The two-phase `advance()` machine (hidden → revealed → next).
- Interval-subset restriction (a disabled interval never appears over 300 draws).
- Answer wiring: minor 3rd above C = E♭ via `transpose`/`simplify`.

## Verification
Drove the running app under Playwright: Notes renders 12 notes; Intervals shows the prompt, tap reveals the simplified answer + theory-correct caption, tap again draws the next; subset toggle works; back to Notes intact. No console errors.

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)