### PR TITLE
fix: improve interval-mode footer layout

### DIFF
--- a/src/components/Settings/IntervalSettings.tsx
+++ b/src/components/Settings/IntervalSettings.tsx
@@ -6,14 +6,20 @@ import { IntervalSubset } from './IntervalSubset';
 import { Timer } from './Timer';
 
 // The interval-mode settings row: the interval-subset selector and the shared
-// Timer. No Count in this mode. Parallel to the note-practice Settings.
+// Timer. No Count in this mode. On wide screens a 1fr | auto | 1fr grid keeps
+// the subset centred while the Timer sits in its own right-hand column (so they
+// can never overlap); on narrow screens they stack, centred. Vertical padding
+// keeps nothing flush with the bottom edge.
 export const IntervalSettings: FC<{
   enabledIntervalNames: IntervalName[];
   toggleInterval: (name: IntervalName) => void;
   setTimerSeconds: (seconds: number | null) => void;
 }> = ({ enabledIntervalNames, toggleInterval, setTimerSeconds }) => (
-  <div className="flex flex-col items-center gap-4 px-4 pt-4 md:flex-row md:justify-between">
+  <div className="grid items-center justify-items-center gap-4 px-4 py-6 md:grid-cols-[1fr_auto_1fr] md:py-8">
+    <div className="hidden md:block" />
     <IntervalSubset enabled={enabledIntervalNames} toggle={toggleInterval} />
-    <Timer onValue={setTimerSeconds} />
+    <div className="md:justify-self-end">
+      <Timer onValue={setTimerSeconds} />
+    </div>
   </div>
 );

--- a/src/components/Settings/IntervalSubset.tsx
+++ b/src/components/Settings/IntervalSubset.tsx
@@ -8,17 +8,15 @@ export const IntervalSubset: FC<{
   enabled: IntervalName[];
   toggle: (name: IntervalName) => void;
 }> = ({ enabled, toggle }) => (
-  <fieldset className="flex flex-wrap items-center justify-center gap-x-3 gap-y-1">
-    <legend className="mb-1 text-gray-400">Intervals</legend>
-    {INTERVALS.map(({ name }) => (
-      <label key={name} className="flex items-center gap-1 text-gray-700">
-        <input
-          type="checkbox"
-          checked={enabled.includes(name)}
-          onChange={() => toggle(name)}
-        />
-        {name}
-      </label>
-    ))}
+  <fieldset className="text-center">
+    <legend className="mb-2 text-gray-400">Intervals</legend>
+    <div className="flex flex-wrap items-center justify-center gap-x-3 gap-y-2">
+      {INTERVALS.map(({ name }) => (
+        <label key={name} className="flex items-center gap-1 text-gray-700">
+          <input type="checkbox" checked={enabled.includes(name)} onChange={() => toggle(name)} />
+          {name}
+        </label>
+      ))}
+    </div>
   </fieldset>
 );


### PR DESCRIPTION
Footer polish for interval practice mode, from review of the live app.

**Before:** the Timer was absolutely positioned on the right and ran *under* the checkbox row near the md breakpoint (e.g. ~800px "major 7th" overlapped the Timer); the subset was left-aligned in wide view; and the Timer sat flush with the bottom edge in narrow view.

**After:**
- A `1fr | auto | 1fr` grid keeps the interval-subset selector centred in the footer while the Timer occupies its own right-hand column — they can never overlap at any width.
- `py-6` / `md:py-8` gives the footer height and stops the Timer sitting flush with the bottom in narrow view.
- `IntervalSubset` stacks its legend above a centred, wrapping checkbox row.

## Verification
Screenshotted the footer under Playwright at 1000px, 800px, and 390px: subset centred at every width, Timer in its own column with no overlap, comfortable vertical padding. Notes mode untouched. `tsc`, `eslint`, and 102 tests all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)