### PR TITLE
fix: enlarge and vertically center note display

### DIFF
--- a/src/components/Notes.tsx
+++ b/src/components/Notes.tsx
@@ -5,7 +5,7 @@ import { format, type Note } from '../note';
 
 export const Notes: FC<{ notes: Note[] }> = ({ notes = [] }) => {
   return (
-    <div className="flex flex-wrap items-center content-center justify-center gap-4">
+    <div className="flex flex-wrap items-center content-center justify-center h-full gap-4">
       {notes.map((note, index) => {
         const colorClass = NOTE_COLORS[note.letter];
         return <NoteView key={format(note) + index} colorClass={colorClass} text={format(note)} />;

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,6 @@
 
 /* Ported from the old tailwind.config.js theme.extend.fontSize. */
 @theme {
-  --text-auto-size: calc(1.5rem + 16 * (100vw - 320px) / (960 - 320));
+  --text-auto-size: calc(2.5rem + 24 * (100vw - 320px) / (960 - 320));
   --text-xxs: 0.5rem;
 }


### PR DESCRIPTION
## What

- Bump note glyph fluid size from **24–40px** to **40–64px** (mobile → desktop). The old floor was too small on mobile.
- Add `h-full` to the `Notes` wrapper so the note display centers vertically in the tap area, matching the intervals view.

## Why

Notes felt too small on mobile and sat at the top of the screen instead of centered.

## Files

- `src/index.css` — `--text-auto-size` fluid calc
- `src/components/Notes.tsx` — wrapper centering